### PR TITLE
Doc fix: delimiter description is rendered incorrectly (n instead of \n)

### DIFF
--- a/docs/src/gen/consumer/socket.rst
+++ b/docs/src/gen/consumer/socket.rst
@@ -92,11 +92,11 @@ Parameters
     
     
 
-**Delimiter** (default: \n)
+**Delimiter** (default: \\n)
 
   This value defines the delimiter used by the text and delimiter
   partitioners.
-  By default this parameter is set to "\n".
+  By default this parameter is set to "\\n".
   
   
 


### PR DESCRIPTION
The delimiter default is \n, but this renders as "n" in restructured text.
\\n produces an \n in the output.
